### PR TITLE
function name detection corrected

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyrologic/pyrologjs",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": "Thomas Hendel",
   "homepage": "https://github.com/pyrologic/pyrologjs",
   "license": "MIT",


### PR DESCRIPTION
# Function name detection corrected
The function name detection based on stack traces did not work properly; other browsers than the Chromium based family  - namely Safari and Firefox - have different schemes for stack traces.
The code in `util.ts` was revised to deal with those differences. See `Utils.getStack()` and `Utils.getFunctionName()`.