### PR TITLE
Replace Level enum with a frozen const object

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **pyrologjs** is a small, lightweight yet powerful logging facility for use in JavaScript and/or TypeScript modules.
 It can be used for web sites as well as in code for nodejs, deno or similar environments.
 
-- **pyrologjs** provides a [hierarchical logger model](#hierarchical-logger-configuration) with the possibility of individual logger configuration. This way, each logger has a configured [logging level](#the-logging-level-enumeration) that acts as a threshold which decides whether an actual logging message is written to the console. Example: If a logger's level is set to `INFO`, then it will write logging
+- **pyrologjs** provides a [hierarchical logger model](#hierarchical-logger-configuration) with the possibility of individual logger configuration. This way, each logger has a configured [logging level](#the-logging-levels) that acts as a threshold which decides whether an actual logging message is written to the console. Example: If a logger's level is set to `INFO`, then it will write logging
 messages at level `INFO` or above to the console, while logging messages at level `DEBUG` or `TRACE` will be ignored.
 
 - **pyrologjs** provides an easy way to [style the logging output](#styling-the-output).
@@ -199,25 +199,18 @@ Each logger has a property called `suspended`. If this property is set to `true`
 loggers at once.
 
 
-### Logging Level Enumeration in JavaScript
+### Logging Levels in JavaScript
 
-The symbolic logging level values are not directly available in JavaScript, since the TypeScript enumeration `Level` is resolved by the TypeScript compiler. In order to deal with that, you can use the object `JsLevel` instead, which provides each logging level as a property:
+The symbolic logging level values are directly available in JavaScript. `Level` is no longer a TypeScript enumeration (which would be resolved away by the compiler) but a plain, frozen object, so you can import and use it from plain JavaScript just as well as from TypeScript:
 ```js
-import { JsLevel } from "@pyrologic/pyrologjs";
+import { Level } from "@pyrologic/pyrologjs";
+
+logger.writeLog(Level.WARN, 'Hello WARN logger!');
 ```
 
-The object `JsLevel` itself is defined like this:
+For backwards compatibility a `JsLevel` alias is still exported, but it is **deprecated** and simply points to `Level`. New code should import `Level` directly:
 ```js
-const JsLevel = {
-    ALL: Level.ALL,
-    TRACE: Level.TRACE,
-    DEBUG: Level.DEBUG,
-    INFO: Level.INFO,
-    WARN: Level.WARN,
-    ERROR: Level.ERROR,
-    FATAL: Level.FATAL,
-    OFF: Level.OFF
-};
+import { JsLevel } from "@pyrologic/pyrologjs"; // deprecated: use `Level` instead
 ```
 
 ### Stack Traces
@@ -601,32 +594,34 @@ interface Logger {
 ```
 
 
-### The Logging Level Enumeration
+### The Logging Levels
 
-All logging levels are elements of the `Level` enumeration:
+All logging levels are properties of the `Level` object. It is a plain, frozen object (not a TypeScript `enum`) so it can be used directly from plain JavaScript as well as from TypeScript. The numeric values reflect the ascending threshold order (`ALL` = 0 … `OFF` = 7): a message is written only if its level is greater than or equal to the logger's configured level.
 ```ts
 /**
  * logging levels
  */
-enum Level {
+const Level = Object.freeze({
     /** logs everything  */
-    ALL,
+    ALL: 0,
     /** TRACE level */
-    TRACE,
+    TRACE: 1,
     /** DEBUG level */
-    DEBUG,
+    DEBUG: 2,
     /** INFO level */
-    INFO,
+    INFO: 3,
     /** WARN level */
-    WARN,
+    WARN: 4,
     /** ERROR level */
-    ERROR,
+    ERROR: 5,
     /** FATAL level */
-    FATAL,
+    FATAL: 6,
     /** loggers at this level do not log at all */
-    OFF
-}
+    OFF: 7
+});
 ```
+
+The type `Level` denotes any of these level values.
 
 
 ### The ConfigItem Interface
@@ -655,7 +650,7 @@ interface ConfigItem {
 }
 ```
 
-Note that `LevelStrings` is the string representation of the `Level` enumeration:
+Note that `LevelStrings` is the string representation of the `Level` values:
 ```ts
 LevelStrings = "ALL" | "TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR" | "FATAL" | "OFF";
 ```

--- a/src/ConfigTree.ts
+++ b/src/ConfigTree.ts
@@ -5,7 +5,7 @@
 import { ConfigItem } from "./ConfigItem";
 import { Utils } from "./utils";
 import { DEFAULT_CONFIG, ROOT_NODE_NAME } from "./Const";
-import { Level } from "./Level";
+import { isLevelString } from "./Level";
 import { PyroConfigItem } from "./PyroConfigItem";
 
 
@@ -186,8 +186,7 @@ export class ConfigTree {
         let dci: ConfigItem|null = null;
         for ( let ci of config ) {
             const name = Utils.normalizePath(ci.name);
-            const level = Level[ci.level];
-            if ( typeof level === 'undefined' ) {
+            if ( !isLevelString(ci.level) ) {
                 throw new Error(`Invalid level "${ci.level}"!`);
             }
             if ( DEFAULT_CONFIG === name ) {

--- a/src/Level.ts
+++ b/src/Level.ts
@@ -1,24 +1,37 @@
 /**
  * logging levels
+ *
+ * Ascending threshold order: a message is written only if its level is
+ * numerically greater than or equal to the logger's configured level.
+ *
+ * This is a plain, frozen object (not a TS `enum`) so it is directly usable
+ * from plain JavaScript consumers while keeping the numeric values that the
+ * level gating relies on. The values are intentionally kept identical to the
+ * former `enum Level` (ALL = 0 … OFF = 7).
  */
-export enum Level {
+export const Level = Object.freeze({
     /** logs everything  */
-    ALL,
+    ALL: 0,
     /** TRACE level */
-    TRACE,
+    TRACE: 1,
     /** DEBUG level */
-    DEBUG,
+    DEBUG: 2,
     /** INFO level */
-    INFO,
+    INFO: 3,
     /** WARN level */
-    WARN,
+    WARN: 4,
     /** ERROR level */
-    ERROR,
+    ERROR: 5,
     /** FATAL level */
-    FATAL,
+    FATAL: 6,
     /** loggers at this level do not log at all */
-    OFF
-}
+    OFF: 7
+} as const);
+
+/**
+ * a logging level value (0…7); the ordinal is significant (see {@link Level})
+ */
+export type Level = typeof Level[keyof typeof Level];
 
 /**
  * a string collection of all supported logging levels
@@ -26,29 +39,21 @@ export enum Level {
 export type LevelStrings = keyof typeof Level;
 
 /**
+ * frozen mapping from level value back to its name (reverse of {@link Level})
+ */
+const LevelNames = Object.freeze(
+    Object.fromEntries(
+        Object.entries(Level).map(([name, value]) => [value, name])
+    ) as Record<Level, LevelStrings>
+);
+
+/**
  * retrieves the name of a logging level
  * @param level logging level
  * @returns the corresponding name (string)
  */
 export function Level2String(level: Level): string {
-    switch ( level ) {
-        case Level.ALL:
-            return "ALL";
-        case Level.TRACE:
-            return "TRACE";
-        case Level.DEBUG:
-            return "DEBUG";
-        case Level.INFO:
-            return "INFO";
-        case Level.WARN:
-            return "WARN";
-        case Level.ERROR:
-            return "ERROR";
-        case Level.FATAL:
-            return "FATAL";
-        case Level.OFF:
-            return "OFF";
-    }
+    return LevelNames[level];
 }
 
 /**
@@ -57,45 +62,34 @@ export function Level2String(level: Level): string {
  * @returns the matching level identifier
  */
 export function Level2LevelString(level: Level): LevelStrings {
-    return Level2String(level) as LevelStrings;
+    return LevelNames[level];
+}
+
+/**
+ * checks whether an arbitrary string is a valid level identifier
+ * @param s arbitrary string
+ * @returns true if `s` names a logging level; false otherwise
+ */
+export function isLevelString(s: string): s is LevelStrings {
+    return Object.prototype.hasOwnProperty.call(Level, s);
 }
 
 /**
  * converts an arbitrary string into a valid level identifier
  * @param s arbitrary string
- * @returns the corresponding level identifier
+ * @returns the corresponding level identifier, or "INFO" if `s` is not a level name
  */
 export function String2LevelString(s: string): LevelStrings {
-    switch ( s ) {
-        case "ALL":
-            return "ALL";
-        case "TRACE":
-            return "TRACE";
-        case "DEBUG":
-            return "DEBUG";
-        case "INFO":
-            return "INFO";
-        case "WARN":
-            return "WARN";
-        case "ERROR":
-            return "ERROR";
-        case "FATAL":
-            return "FATAL";
-        case "OFF":
-            return "OFF";
-        default:
-            return "INFO";
-    }
+    return isLevelString(s) ? s : "INFO";
 }
 
 /**
- * converts a string providing a level name into the corresponding Level enumeration value
+ * converts a string providing a level name into the corresponding Level value
  * @param s string providing a level name
- * @returns the corresponding Level enumeration value
+ * @returns the corresponding Level value, or Level.INFO if `s` is not a level name
  */
 export function String2Level(s: string): Level {
-    const level = Level[String2LevelString(s)];
-    return level !== undefined ? level : Level.INFO;
+    return Level[String2LevelString(s)];
 }
 
 /**
@@ -104,6 +98,6 @@ export function String2Level(s: string): Level {
  */
 export function forEachLevel( f: (level: Level) => void ): void {
     for ( let l = Level.ALL ; l <= Level.OFF ; ++l ) {
-        f(l);
+        f(l as Level);
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -176,17 +176,11 @@ class PyroLog {
 // create the singleton instance
 const pyroLog = PyroLog._create();
 
-// create Level enumeration as JS object
-const JsLevel = Object.freeze({
-    ALL: Level.ALL,
-    TRACE: Level.TRACE,
-    DEBUG: Level.DEBUG,
-    INFO: Level.INFO,
-    WARN: Level.WARN,
-    ERROR: Level.ERROR,
-    FATAL: Level.FATAL,
-    OFF: Level.OFF
-});
+/**
+ * @deprecated `Level` is now itself a plain frozen object and can be used
+ * directly from JavaScript; `JsLevel` is retained as an alias for compatibility.
+ */
+const JsLevel = Level;
 
 // export everything that should be exported
 export { 


### PR DESCRIPTION
## Summary

Refactors the logging `Level` type to eliminate the duplication between `enum Level`, `JsLevel`, and the hand-written `Level2String` / `String2LevelString` switch statements — collapsing all of it into a single frozen `as const` object.

## Motivation

There were effectively four hand-maintained copies of the eight level symbols. A plain string-literal union was considered but rejected: log levels are **ordinal** (gating relies on `l >= this.level`), and going pure-string would break the numeric public contract and just move the number↔string mapping into a rank table. A numeric-valued `as const` object keeps the ordering, keeps the values, and is directly usable from JS — which is exactly what `JsLevel` was manually reconstructing.

## Changes

- **`Level.ts`** — `enum Level` → frozen `as const` object with identical values (`ALL=0` … `OFF=7`). The two `switch` walls collapse into a derived reverse-lookup table. Added `isLevelString()` type guard.
- **`main.ts`** — `JsLevel` is now a deprecated alias of `Level` (kept for compatibility) instead of a hand-built copy.
- **`ConfigTree.ts`** — config-level validation uses `isLevelString()` instead of the `Level[…]` / `typeof … === 'undefined'` pattern.

## Compatibility

- `Level.INFO` is still `3` at runtime; ordinal gating, `forEachLevel`, and the `writeLog` switch are untouched.
- `LevelStrings` is byte-identical; all public signatures still read `Level`.
- `JsLevel` remains exported.
- **Caveat:** a numeric enum provided a reverse map (`Level[3] === "INFO"`); a plain object does not. No internal code relied on it (all internal lookups are forward string→number). A consumer doing `Level[3]` should use `Level2String()` instead — worth a changelog note.

## Verification

`npm run build` passes with no warnings (rollup does the type-checking via `@rollup/plugin-typescript`). No test suite exists in this repo.